### PR TITLE
Add RBAC permissions to reports controller

### DIFF
--- a/config/kyverno/rbac.yaml
+++ b/config/kyverno/rbac.yaml
@@ -2,26 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: admission-controller
-    app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/part-of: kyverno
-  name: kyverno-vpa-admission
-rules:
-- apiGroups:
-  - autoscaling.k8s.io
-  resources:
-  - verticalpodautoscalers
-  verbs:
-  - create
-  - update
-  - delete
-  - list
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
     app.kubernetes.io/part-of: kyverno

--- a/config/kyverno/rbac.yaml
+++ b/config/kyverno/rbac.yaml
@@ -2,10 +2,30 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: background-controller
+    app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
     app.kubernetes.io/part-of: kyverno
-  name: kyverno-vpa
+  name: kyverno-vpa-admission
+rules:
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - create
+  - update
+  - delete
+  - list
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: reports-controller
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/part-of: kyverno
+  name: kyverno-vpa-reports
 rules:
 - apiGroups:
   - autoscaling.k8s.io


### PR DESCRIPTION
Reports controller is responsible for doing background scans. Therefore, the permission should be on reports controller when we want to generate reports for existing resources.